### PR TITLE
Use clientWidth and height not canvas

### DIFF
--- a/jquery.flot.spider.js
+++ b/jquery.flot.spider.js
@@ -162,8 +162,8 @@
 		}
 
 		function setupspider(ctx) {
-			centerTop = (ctx.canvas.height / 2);
-			centerLeft = (ctx.canvas.width / 2);
+			centerTop = (ctx.canvas.clientHeight / 2);
+			centerLeft = (ctx.canvas.clientWidth / 2);
 			maxRadius = Math.min(centerTop, centerLeft) * data[0].spider.spiderSize;
 		}
 


### PR DESCRIPTION
Seems a change in Plot may have broken this? Charts rendering twice the height/width (even in the demo - http://jsfiddle.net/SpartakusMd/peehncrg/)